### PR TITLE
Integrate with Travis and AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: csharp
+
+sudo: false  # use the new container-based Travis infrastructure
+
+before_install:
+  - cd src
+
+install:
+  - mono .paket/paket.bootstrapper.exe
+  - mono .paket/paket.exe restore
+
+cache:
+  - src/.paket
+  - src/packages
+
+script:
+  - xbuild MonoDevelop.Paket.sln

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Provides [Paket](http://fsprojects.github.io/Paket/) support for MonoDevelop and
 
 For more details see the [Paket Support in Xamarin Studio blog post](http://lastexitcode.com/blog/2015/06/09/PaketSupportInXamarinStudio/)
 
+## Build Status
+
+Mono | .NET
+---- | ----
+[![Mono CI Build Status](https://img.shields.io/travis/mrward/monodevelop-paket-addin/master.svg)](https://travis-ci.org/mrward/monodevelop-paket-addin) | [![.NET CI Build Status](https://img.shields.io/appveyor/ci/mrward/monodevelop-paket-addin/master.svg)](https://ci.appveyor.com/project/mrward/monodevelop-paket-addin)
+
 # Features Overview
 
  * View dependencies and referenced NuGet packages in the Solution window.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+init:
+  - git config --global core.autocrlf input
+install:
+  - if not exist gtk-sharp-2.12.38.msi appveyor DownloadFile http://download.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.38.msi
+  - msiexec /i gtk-sharp-2.12.38.msi /qn /norestart
+  - cmd: cd src
+  - cmd: .paket\paket.bootstrapper.exe
+  - cmd: .paket\paket.exe restore
+cache:
+  - gtk-sharp-2.12.38.msi
+  - src\.paket
+  - src\packages
+build_script:
+  - cmd: msbuild MonoDevelop.Paket.sln
+test: off
+version: 0.0.1.{build}
+artifacts:
+  - path: bin
+    name: MonoDevelop.Paket


### PR DESCRIPTION
AppVeyor seems to be OK
But I'm having a problem with Mono on Travis. It fails with

```
Mono.CSharp.InternalErrorException: Failed to import assembly `System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' ---> System.ArgumentException: Value does not fall within the expected range.
```

you can see both logs here: [AppVeyor](https://ci.appveyor.com/project/sideeffffect/monodevelop-paket-addin), [Travis](https://travis-ci.org/sideeffffect/monodevelop-paket-addin)

could you please help me with this?
